### PR TITLE
Update all dependencies to latest versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,10 @@
-source 'https://rubygems.org' do
-  gem 'sinatra'
-  gem 'twilio-ruby'
-end
+source 'https://rubygems.org'
+
+ruby '>= 3.0'
+
+gem 'sinatra', '~> 4.0'
+gem 'twilio-ruby', '~> 7.0'
+
+# Required for Sinatra 4.x
+gem 'rackup'
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,84 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (1.0.0)
-      multipart-post (>= 1.2, < 3)
-    jwt (2.2.1)
-    mini_portile2 (2.4.0)
-    multipart-post (2.1.1)
-    mustermann (1.1.1)
+    base64 (0.3.0)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    json (2.18.0)
+    jwt (3.1.2)
+      base64
+    logger (1.7.0)
+    mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
-    rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
-    ruby2_keywords (0.0.2)
-    sinatra (2.0.8.1)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nio4r (2.7.5)
+    nokogiri (1.19.0-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-musl)
+      racc (~> 1.4)
+    puma (7.1.0)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (3.2.4)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.3.1)
+      rack (>= 3)
+    ruby2_keywords (0.0.5)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    tilt (2.0.10)
-    twilio-ruby (5.32.0)
-      faraday (~> 1.0.0)
-      jwt (>= 1.5, <= 2.5)
+    tilt (2.7.0)
+    twilio-ruby (7.9.1)
+      faraday (>= 0.9, < 3.0)
+      jwt (>= 1.5, < 4.0)
       nokogiri (>= 1.6, < 2.0)
+    uri (1.1.1)
 
 PLATFORMS
-  ruby
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  sinatra!
-  twilio-ruby!
+  puma
+  rackup
+  sinatra (~> 4.0)
+  twilio-ruby (~> 7.0)
+
+RUBY VERSION
+   ruby 3.3.6p108
 
 BUNDLED WITH
-   1.17.3
+   2.5.22


### PR DESCRIPTION
- Sinatra: 2.0.8.1 → 4.2.1
- twilio-ruby: 5.32.0 → 7.9.1
- nokogiri: 1.10.9 → 1.19.0 (security patches)
- rack: 2.2.3 → 3.2.4
- bundler: 1.17.3 → 2.5.22

Add Ruby 3.0+ requirement and include rackup/puma for Sinatra 4.x